### PR TITLE
Copy SSH Key with copy rather than template module

### DIFF
--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -1,6 +1,6 @@
 ---
 - name: ANSISTRANO | GIT | Ensure GIT deployment key is up to date
-  template:
+  copy:
     src: "{{ ansistrano_git_identity_key_path }}"
     dest: "{{ ansistrano_deploy_to }}/git_identity_key"
     mode: 0400


### PR DESCRIPTION
Doing so adds support for copying encrypted keys files directly. 

This was added to ansible in 2.1 to the copy command but seemingly not to template.

I tried a workaround with a before-setup script but in order to update git by ssh key a source file is required to be defined. When doing so, it overwrites the valid SSH key that was placed via custom task with the encrypted file.